### PR TITLE
USB: fix error with infinite timeout in interface

### DIFF
--- a/pyvisa-py/usb.py
+++ b/pyvisa-py/usb.py
@@ -71,7 +71,7 @@ class USBSession(Session):
 
     def _get_timeout(self, attribute):
         if self.interface:
-            if self.interface.timeout == 2**32-1:
+            if self.interface.timeout is None or self.interface.timeout == 2**32-1:
                 self.timeout = None
             else:
                 self.timeout = self.interface.timeout / 1000


### PR DESCRIPTION
If on ``self.interface`` the timeout is never set or explicitly set to ``None`` this function will raise an exception on line 77 (``TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'``). Therefore I suggest this change, which was probably the intent of the author.